### PR TITLE
Fix documentation deployment for stable version

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,4 +16,6 @@ makedocs(sitename = "FiniteStateProjection.jl",
         "Examples" => "examples.md"
     ])
 
-deploydocs(repo = "github.com/kaandocal/FiniteStateProjection.jl.git", devbranch = "main")
+deploydocs(repo = "github.com/SciML/FiniteStateProjection.jl.git",
+    devbranch = "main",
+    push_preview = true)


### PR DESCRIPTION
## Summary
- Fixed `deploydocs` repo URL from `kaandocal/FiniteStateProjection.jl` to `SciML/FiniteStateProjection.jl`
- Added `push_preview=true` for PR preview builds

## Problem
Currently there is only documentation for the dev version of the package (https://docs.sciml.ai/FiniteStateProjection/dev/). The stable version (https://docs.sciml.ai/FiniteStateProjection/stable/) does not exist.

## Root Cause
The `deploydocs` function in `docs/make.jl` was pointing to the old repository URL (`kaandocal/FiniteStateProjection.jl`) instead of the current SciML organization URL. This prevented Documenter.jl from properly deploying both stable and dev documentation versions.

## Solution
Changed the `deploydocs` repo URL to point to the correct SciML repository. With this fix, Documenter.jl will:
1. Deploy "stable" documentation when tags (releases) are pushed
2. Deploy "dev" documentation when commits are pushed to main
3. Deploy preview documentation for PRs

Fixes #24

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)