### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/demo/birth_death.jl
+++ b/demo/birth_death.jl
@@ -26,7 +26,7 @@ prob = ODEProblem(sys, u0, 10.0, ps)
 
 ##
 
-sol = solve(prob, Vern7(), dense = false, save_everystep = false, abstol = 1e-6)
+sol = solve(prob, Vern7(), dense = false, save_everystep = false, abstol = 1.0e-6)
 
 ##
 

--- a/demo/telegraph.jl
+++ b/demo/telegraph.jl
@@ -37,7 +37,7 @@ prob = ODEProblem(sys, u0, 10.0, ps)
 
 ##
 
-sol = solve(prob, Vern7(), dense = false, save_everystep = false, abstol = 1e-6)
+sol = solve(prob, Vern7(), dense = false, save_everystep = false, abstol = 1.0e-6)
 
 ##
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,8 @@ using Documenter
 using FiniteStateProjection
 using SparseArrays
 
-makedocs(sitename = "FiniteStateProjection.jl",
+makedocs(
+    sitename = "FiniteStateProjection.jl",
     modules = [FiniteStateProjection],
     format = Documenter.HTML(prettyurls = false),
     pages = [
@@ -13,9 +14,12 @@ makedocs(sitename = "FiniteStateProjection.jl",
         "Internal API" => "internal.md",
         "Tips & Tricks" => "tips.md",
         "Troubleshooting" => "troubleshoot.md",
-        "Examples" => "examples.md"
-    ])
+        "Examples" => "examples.md",
+    ]
+)
 
-deploydocs(repo = "github.com/SciML/FiniteStateProjection.jl.git",
+deploydocs(
+    repo = "github.com/SciML/FiniteStateProjection.jl.git",
     devbranch = "main",
-    push_preview = true)
+    push_preview = true
+)

--- a/src/build_rhs.jl
+++ b/src/build_rhs.jl
@@ -11,7 +11,7 @@ See also: [`build_rhs_header`](@ref), [`build_rhs`](@ref)
 function unpackparams(sys::FSPSystem, psym::Symbol)
     param_names = Expr(:tuple, map(par -> par.name, Catalyst.parameters(sys.rs))...)
 
-    quote
+    return quote
         $(param_names) = $(psym)
     end
 end
@@ -26,7 +26,7 @@ just unpacks parameters from `p`.
 See also: [`unpackparams`](@ref), [`build_rhs`](@ref)
 """
 function build_rhs_header(sys::FSPSystem)
-    quote
+    return quote
         ps = p
         $(unpackparams(sys, :ps))
     end
@@ -50,7 +50,7 @@ function build_rhs_firstpass(sys::FSPSystem)
     first_line = :(du[idx_in] = -u[idx_in] * $(sys.rfs[1].body))
     other_lines = (:(du[idx_in] -= u[idx_in] * $(rf.body)) for rf in sys.rfs[2:end])
 
-    quote
+    return quote
         for idx_in in singleindices($(sys.ih), u)
             $first_line
             $(other_lines...)
@@ -106,7 +106,7 @@ function build_rhs_ex(sys::FSPSystem; striplines::Bool = false)
 
     ex = ex |> MacroTools.flatten |> MacroTools.prettify
 
-    ex
+    return ex
 end
 
 """
@@ -116,7 +116,7 @@ Builds the function `f(du,u,p,t)` that defines the right-hand side of the CME
 for use with DifferentialEquations.jl.
 """
 function build_rhs(sys::FSPSystem)
-    @RuntimeGeneratedFunction(build_rhs_ex(sys; striplines = false))
+    return @RuntimeGeneratedFunction(build_rhs_ex(sys; striplines = false))
 end
 
 ##
@@ -141,5 +141,5 @@ calls `convert(ODEFunction, sys)`. It is usually more efficient to create an `OD
 first and then use that to create `ODEProblem`s.
 """
 function DiffEqBase.ODEProblem(sys::FSPSystem, u0, tint, pmap = NullParameters())
-    ODEProblem(convert(ODEFunction, sys), u0, tint, pmap_to_p(sys, pmap))
+    return ODEProblem(convert(ODEFunction, sys), u0, tint, pmap_to_p(sys, pmap))
 end

--- a/src/build_rhs_ss.jl
+++ b/src/build_rhs_ss.jl
@@ -45,7 +45,7 @@ function build_rhs_ex_ss(sys::FSPSystem; striplines::Bool = false)
 
     ex = ex |> MacroTools.flatten |> MacroTools.prettify
 
-    ex
+    return ex
 end
 
 """
@@ -55,7 +55,7 @@ Builds the function `f(du,u,p,t)` that defines the right-hand side of the CME
 for use with `SteadyStateProblem`s.
 """
 function build_rhs_ss(sys::FSPSystem)
-    @RuntimeGeneratedFunction(build_rhs_ex_ss(sys; striplines = false))
+    return @RuntimeGeneratedFunction(build_rhs_ex_ss(sys; striplines = false))
 end
 
 ##
@@ -67,7 +67,7 @@ Return an `ODEFunction` defining the right-hand side of the CME, for use
 with `SteadyStateProblem`s.
 """
 function Base.convert(::Type{ODEFunction}, sys::FSPSystem, ::SteadyState)
-    ODEFunction{true}(build_rhs_ss(sys))
+    return ODEFunction{true}(build_rhs_ss(sys))
 end
 
 """
@@ -76,5 +76,5 @@ end
 Return a `SteadyStateProblem` for use in `DifferentialEquations.
 """
 function DiffEqBase.SteadyStateProblem(sys::FSPSystem, u0, pmap = NullParameters())
-    SteadyStateProblem(convert(ODEFunction, sys, SteadyState()), u0, pmap_to_p(sys, pmap))
+    return SteadyStateProblem(convert(ODEFunction, sys, SteadyState()), u0, pmap_to_p(sys, pmap))
 end

--- a/src/fspsystem.jl
+++ b/src/fspsystem.jl
@@ -9,20 +9,22 @@ struct FSPSystem{IHT <: AbstractIndexHandler, RT}
     rfs::RT
 end
 
-function FSPSystem(rs::ReactionSystem,
+function FSPSystem(
+        rs::ReactionSystem,
         ih::AbstractIndexHandler = DefaultIndexHandler{length(Catalyst.species(rs))}();
-        combinatoric_ratelaw::Bool = true)
+        combinatoric_ratelaw::Bool = true
+    )
     isempty(Catalyst.get_systems(rs)) ||
         error("Supported Catalyst models can not contain subsystems. Please use `rs = Catalyst.flatten(rs::ReactionSystem)` to generate a single system with no subsystems from your Catalyst model.")
     any(eq -> !(eq isa Reaction), equations(rs)) &&
         error("Catalyst models that include constraint ODEs or algebraic equations are not supported.")
 
     rfs = create_ratefuncs(rs, ih; combinatoric_ratelaw = combinatoric_ratelaw)
-    FSPSystem(rs, ih, rfs)
+    return FSPSystem(rs, ih, rfs)
 end
 
 function FSPSystem(rs::ReactionSystem, order::AbstractVector{Symbol}; kwargs...)
-    FSPSystem(rs, PermutingIndexHandler(rs, order); kwargs...)
+    return FSPSystem(rs, PermutingIndexHandler(rs, order); kwargs...)
 end
 
 """
@@ -33,8 +35,10 @@ Return the rate functions converted to Julia expressions in the state variable
 
 See also: [`getsubstitutions`](@ref), [`build_rhs`](@ref)
 """
-function build_ratefuncs(rs::ReactionSystem, ih::AbstractIndexHandler;
-        state_sym::Symbol, combinatoric_ratelaw::Bool = true)
+function build_ratefuncs(
+        rs::ReactionSystem, ih::AbstractIndexHandler;
+        state_sym::Symbol, combinatoric_ratelaw::Bool = true
+    )
     substitutions = getsubstitutions(ih, rs, state_sym = state_sym)
 
     return map(Catalyst.reactions(rs)) do reac
@@ -47,18 +51,22 @@ end
 function create_ratefuncs(rs::ReactionSystem, ih::AbstractIndexHandler; combinatoric_ratelaw::Bool = true)
     paramsyms = Symbol.(Catalyst.parameters(rs))
 
-    return tuple(map(ex -> compile_ratefunc(ex, paramsyms),
-        build_ratefuncs(rs, ih; state_sym = :idx_in, combinatoric_ratelaw))...)
+    return tuple(
+        map(
+            ex -> compile_ratefunc(ex, paramsyms),
+            build_ratefuncs(rs, ih; state_sym = :idx_in, combinatoric_ratelaw)
+        )...
+    )
 end
 
 function compile_ratefunc(ex_rf, params)
     # Make this nicer in the future
     ex = :((idx_in, t, $(params...)) -> $(ex_rf)) |> MacroTools.flatten
-    @RuntimeGeneratedFunction(ex)
+    return @RuntimeGeneratedFunction(ex)
 end
 
 function pmap_to_p(sys::FSPSystem, pmap)
     pmap_conv = eltype(pmap) <: Pair{Symbol} ? Catalyst.symmap_to_varmap(sys.rs, pmap) :
-                pmap
-    ModelingToolkit.varmap_to_vars(pmap_conv, Catalyst.parameters(sys.rs))
+        pmap
+    return ModelingToolkit.varmap_to_vars(pmap_conv, Catalyst.parameters(sys.rs))
 end

--- a/src/indexhandlers.jl
+++ b/src/indexhandlers.jl
@@ -79,31 +79,45 @@ DefaultIndexHandler{N}() where {N} = DefaultIndexHandler{N}(1, Tuple(1:N))
 Base.vec(::DefaultIndexHandler, arr) = vec(arr)
 Base.LinearIndices(::DefaultIndexHandler, arr) = LinearIndices(arr)
 
-function pairedindices(ih::DefaultIndexHandler{N}, arr::AbstractArray{T, N},
-        shift::CartesianIndex{N}) where {T, N}
-    pairedindices(ih, axes(arr), shift)
+function pairedindices(
+        ih::DefaultIndexHandler{N}, arr::AbstractArray{T, N},
+        shift::CartesianIndex{N}
+    ) where {T, N}
+    return pairedindices(ih, axes(arr), shift)
 end
 
-function pairedindices(ih::DefaultIndexHandler{N}, dims::NTuple{N, T},
-        shift::CartesianIndex{N}) where {N, T <: Number}
-    pairedindices(ih, Base.OneTo.(dims), shift)
+function pairedindices(
+        ih::DefaultIndexHandler{N}, dims::NTuple{N, T},
+        shift::CartesianIndex{N}
+    ) where {N, T <: Number}
+    return pairedindices(ih, Base.OneTo.(dims), shift)
 end
 
 # Important: the species in `shift` are ordered according to `Catalyst.species`!
-function pairedindices(ih::DefaultIndexHandler{N}, dims::NTuple{N, T},
-        shift::CartesianIndex{N}) where {N, T <: AbstractVector}
-    ranges = tuple((UnitRange(max(first(ax), first(ax)+shift[ih.perm[i]]),
-                        min(last(ax), last(ax)+shift[ih.perm[i]]))
-    for (i, ax) in enumerate(dims))...)
+function pairedindices(
+        ih::DefaultIndexHandler{N}, dims::NTuple{N, T},
+        shift::CartesianIndex{N}
+    ) where {N, T <: AbstractVector}
+    ranges = tuple(
+        (
+            UnitRange(
+                    max(first(ax), first(ax) + shift[ih.perm[i]]),
+                    min(last(ax), last(ax) + shift[ih.perm[i]])
+                )
+                for (i, ax) in enumerate(dims)
+        )...
+    )
 
     ranges_shifted = tuple((rng .- shift[ih.perm[i]] for (i, rng) in enumerate(ranges))...)
 
-    zip(CartesianIndices(ranges_shifted), CartesianIndices(ranges))
+    return zip(CartesianIndices(ranges_shifted), CartesianIndices(ranges))
 end
 
-function pairedindices(::DefaultIndexHandler, dims::NTuple{N, T},
-        shift::CartesianIndex{M}) where {N, M, T <: AbstractVector}
-    @error "Dimension of state space ($(length(dims))) does not match number of species ($(length(shift)))"
+function pairedindices(
+        ::DefaultIndexHandler, dims::NTuple{N, T},
+        shift::CartesianIndex{M}
+    ) where {N, M, T <: AbstractVector}
+    return @error "Dimension of state space ($(length(dims))) does not match number of species ($(length(shift)))"
 end
 
 """
@@ -118,7 +132,7 @@ function getsubstitutions(ih::DefaultIndexHandler, rs::ReactionSystem; state_sym
     species_orig = species(rs)
     species_perm = [species_orig[ih.perm[i]] for i in 1:nspecs]
 
-    Dict(symbol => state_sym_vec[i] - ih.offset for (i, symbol) in enumerate(species_perm))
+    return Dict(symbol => state_sym_vec[i] - ih.offset for (i, symbol) in enumerate(species_perm))
 end
 
 #"""
@@ -128,7 +142,7 @@ end
 #defined by the vector `order`.
 #"""
 function PermutingIndexHandler(rs::ReactionSystem, order::AbstractVector{Symbol})
-    PermutingIndexHandler(rs, map(sym -> Catalyst._symbol_to_var(rs, sym), order))
+    return PermutingIndexHandler(rs, map(sym -> Catalyst._symbol_to_var(rs, sym), order))
 end
 
 function PermutingIndexHandler(rs::ReactionSystem, order::AbstractVector)
@@ -158,5 +172,5 @@ function PermutingIndexHandler(rs::ReactionSystem, order::AbstractVector)
 
     @assert count == ones(Int, nspec)
 
-    DefaultIndexHandler(1, Tuple(perm))
+    return DefaultIndexHandler(1, Tuple(perm))
 end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -38,7 +38,7 @@ function create_sparsematrix(sys::FSPSystem, dims::NTuple, ps, t)
         end
     end
 
-    sparse(I, J, V)
+    return sparse(I, J, V)
 end
 
 function create_sparsematrix_ss(sys::FSPSystem, dims::NTuple, ps)
@@ -72,7 +72,7 @@ function create_sparsematrix_ss(sys::FSPSystem, dims::NTuple, ps)
         end
     end
 
-    sparse(I, J, V)
+    return sparse(I, J, V)
 end
 
 """
@@ -84,7 +84,7 @@ Chemical Master Equation. `dims` is a tuple denoting the dimensions of the FSP a
 of the state obtained using `vec`.
 """
 function SparseArrays.SparseMatrixCSC(sys::FSPSystem, dims::NTuple, pmap, t::Real)
-    create_sparsematrix(sys, dims, pmap_to_p(sys, pmap), t)
+    return create_sparsematrix(sys, dims, pmap_to_p(sys, pmap), t)
 end
 
 """
@@ -94,5 +94,5 @@ Convert the reaction system into a sparse matrix defining the right-hand side of
 Chemical Master Equation, steady-state version.
 """
 function SparseArrays.SparseMatrixCSC(sys::FSPSystem, dims::NTuple, pmap, ::SteadyState)
-    create_sparsematrix_ss(sys, dims, pmap_to_p(sys, pmap))
+    return create_sparsematrix_ss(sys, dims, pmap_to_p(sys, pmap))
 end

--- a/test/birthdeath2D.jl
+++ b/test/birthdeath2D.jl
@@ -20,47 +20,49 @@ sys = FSPSystem(rs)
 
 prs = exp.(2 .* rand(2))
 
-pmap = [:r1 => prs[1],
+pmap = [
+    :r1 => prs[1],
     :r2 => prs[1] / exp(2 * rand()),
     :s1 => prs[2],
-    :s2 => prs[2] / exp(2 * rand())]
+    :s2 => prs[2] / exp(2 * rand()),
+]
 
 ps = last.(pmap)
 
 Nmax = 45
 
-u0 = zeros(Nmax+1, Nmax+1)
+u0 = zeros(Nmax + 1, Nmax + 1)
 u0[1] = 1.0
 
 tt = [0.25, 1.0, 10.0]
 
 prob = ODEProblem(sys, u0, 10.0, pmap)
-sol = solve(prob, Vern7(), abstol = 1e-6, saveat = tt)
+sol = solve(prob, Vern7(), abstol = 1.0e-6, saveat = tt)
 
 @test marg(sol.u[1], dims = 2) ≈
-      pdf.(Poisson(ps[1] / ps[2] * (1 - exp(-ps[2] * tt[1]))), 0:Nmax) atol=1e-4
+    pdf.(Poisson(ps[1] / ps[2] * (1 - exp(-ps[2] * tt[1]))), 0:Nmax) atol = 1.0e-4
 @test marg(sol.u[1], dims = 1) ≈
-      pdf.(Poisson(ps[3] / ps[4] * (1 - exp(-ps[4] * tt[1]))), 0:Nmax) atol=1e-4
+    pdf.(Poisson(ps[3] / ps[4] * (1 - exp(-ps[4] * tt[1]))), 0:Nmax) atol = 1.0e-4
 
 @test marg(sol.u[2], dims = 2) ≈
-      pdf.(Poisson(ps[1] / ps[2] * (1 - exp(-ps[2] * tt[2]))), 0:Nmax) atol=1e-4
+    pdf.(Poisson(ps[1] / ps[2] * (1 - exp(-ps[2] * tt[2]))), 0:Nmax) atol = 1.0e-4
 @test marg(sol.u[2], dims = 1) ≈
-      pdf.(Poisson(ps[3] / ps[4] * (1 - exp(-ps[4] * tt[2]))), 0:Nmax) atol=1e-4
+    pdf.(Poisson(ps[3] / ps[4] * (1 - exp(-ps[4] * tt[2]))), 0:Nmax) atol = 1.0e-4
 
 @test marg(sol.u[3], dims = 2) ≈
-      pdf.(Poisson(ps[1] / ps[2] * (1 - exp(-ps[2] * tt[3]))), 0:Nmax) atol=1e-4
+    pdf.(Poisson(ps[1] / ps[2] * (1 - exp(-ps[2] * tt[3]))), 0:Nmax) atol = 1.0e-4
 @test marg(sol.u[3], dims = 1) ≈
-      pdf.(Poisson(ps[3] / ps[4] * (1 - exp(-ps[4] * tt[3]))), 0:Nmax) atol=1e-4
+    pdf.(Poisson(ps[3] / ps[4] * (1 - exp(-ps[4] * tt[3]))), 0:Nmax) atol = 1.0e-4
 
-A = SparseMatrixCSC(sys, (Nmax+1, Nmax+1), pmap, 0)
+A = SparseMatrixCSC(sys, (Nmax + 1, Nmax + 1), pmap, 0)
 f = (du, u, p, t) -> mul!(vec(du), A, vec(u))
 
 probA = ODEProblem(f, u0, 10.0)
-solA = solve(probA, Vern7(), abstol = 1e-6, saveat = tt)
+solA = solve(probA, Vern7(), abstol = 1.0e-6, saveat = tt)
 
-@test sol.u[1] ≈ solA.u[1] atol=1e-4
-@test sol.u[2] ≈ solA.u[2] atol=1e-4
-@test sol.u[3] ≈ solA.u[3] atol=1e-4
+@test sol.u[1] ≈ solA.u[1] atol = 1.0e-4
+@test sol.u[2] ≈ solA.u[2] atol = 1.0e-4
+@test sol.u[3] ≈ solA.u[3] atol = 1.0e-4
 
 ## Steady-State Tests
 
@@ -68,17 +70,17 @@ prob_ss = SteadyStateProblem(sys, u0, pmap)
 sol_ss = solve(prob_ss, SSRootfind())
 sol_ss.u ./= sum(sol_ss.u)
 
-@test marg(sol_ss.u, dims = 2) ≈ pdf.(Poisson(ps[1] / ps[2]), 0:Nmax) atol=1e-4
-@test marg(sol_ss.u, dims = 1) ≈ pdf.(Poisson(ps[3] / ps[4]), 0:Nmax) atol=1e-4
+@test marg(sol_ss.u, dims = 2) ≈ pdf.(Poisson(ps[1] / ps[2]), 0:Nmax) atol = 1.0e-4
+@test marg(sol_ss.u, dims = 1) ≈ pdf.(Poisson(ps[3] / ps[4]), 0:Nmax) atol = 1.0e-4
 
-A_ss = SparseMatrixCSC(sys, (Nmax+1, Nmax+1), pmap, SteadyState())
+A_ss = SparseMatrixCSC(sys, (Nmax + 1, Nmax + 1), pmap, SteadyState())
 f_ss = (du, u, p, t) -> mul!(vec(du), A_ss, vec(u))
 
 probA_ss = SteadyStateProblem(f_ss, u0)
 solA_ss = solve(probA_ss, SSRootfind())
 solA_ss.u ./= sum(solA_ss.u)
 
-@test sol_ss.u ≈ solA_ss.u atol=1e-4
+@test sol_ss.u ≈ solA_ss.u atol = 1.0e-4
 
 ## Permutation tests
 
@@ -86,23 +88,23 @@ sys_perm = FSPSystem(rs, [:B, :A])
 
 u0_perm = u0'
 
-A_perm = SparseMatrixCSC(sys_perm, (Nmax+1, Nmax+1), pmap, 0)
+A_perm = SparseMatrixCSC(sys_perm, (Nmax + 1, Nmax + 1), pmap, 0)
 
-idx_perm = vec(reshape(1:((Nmax + 1) ^ 2), (Nmax+1, Nmax+1))')
-P = sparse(1:((Nmax + 1) ^ 2), idx_perm, 1)'
+idx_perm = vec(reshape(1:((Nmax + 1)^2), (Nmax + 1, Nmax + 1))')
+P = sparse(1:((Nmax + 1)^2), idx_perm, 1)'
 
 @test A_perm ≈ P * A * P'
 
 prob_perm = ODEProblem(sys_perm, u0_perm, 10.0, pmap)
-sol_perm = solve(prob_perm, Vern7(), abstol = 1e-6, saveat = tt)
+sol_perm = solve(prob_perm, Vern7(), abstol = 1.0e-6, saveat = tt)
 
-@test sol_perm.u[1] ≈ sol.u[1]' atol=1e-4
-@test sol_perm.u[2] ≈ sol.u[2]' atol=1e-4
-@test sol_perm.u[3] ≈ sol.u[3]' atol=1e-4
+@test sol_perm.u[1] ≈ sol.u[1]' atol = 1.0e-4
+@test sol_perm.u[2] ≈ sol.u[2]' atol = 1.0e-4
+@test sol_perm.u[3] ≈ sol.u[3]' atol = 1.0e-4
 
 ## Steady-State Tests
 
-A_fsp_ss_perm = SparseMatrixCSC(sys_perm, (Nmax+1, Nmax+1), pmap, SteadyState())
+A_fsp_ss_perm = SparseMatrixCSC(sys_perm, (Nmax + 1, Nmax + 1), pmap, SteadyState())
 
 @test A_fsp_ss_perm ≈ P * A_ss * P'
 
@@ -110,4 +112,4 @@ prob_ss_perm = SteadyStateProblem(sys_perm, u0_perm, pmap)
 sol_ss_perm = solve(prob_ss_perm, SSRootfind())
 sol_ss_perm.u ./= sum(sol_ss_perm.u)
 
-@test sol_ss_perm.u ≈ sol_ss.u' atol=1e-4
+@test sol_ss_perm.u ≈ sol_ss.u' atol = 1.0e-4

--- a/test/feedbackloop.jl
+++ b/test/feedbackloop.jl
@@ -11,15 +11,17 @@ rs = @reaction_network begin
     σ_off, G + P → 0
     σ_on * (1 - G), 0 ⇒ G + P
     ρ_on, G → G + P
-    ρ_off * (1-G), 0 ⇒ P
+    ρ_off * (1 - G), 0 ⇒ P
     d, P → 0
 end
 
-pmap = [:σ_off => 1,
+pmap = [
+    :σ_off => 1,
     :σ_on => 0.1,
     :ρ_on => 20,
     :ρ_off => 1,
-    :d => 1]
+    :d => 1,
+]
 
 ps = last.(pmap)
 
@@ -30,20 +32,28 @@ sys = FSPSystem(rs)
 function create_A(ps, Nmax)
     σ_off, σ_on, ρ_on, ρ_off, d = ps
 
-    A00 = sparse([j == i ? -(ρ_off + σ_on + (i-1) * d) :
-                  j == i - 1 ? ρ_off : j == i + 1 ? i * d : 0 for i in 1:Nmax, j in 1:Nmax])
+    A00 = sparse(
+        [
+            j == i ? -(ρ_off + σ_on + (i - 1) * d) :
+                j == i - 1 ? ρ_off : j == i + 1 ? i * d : 0 for i in 1:Nmax, j in 1:Nmax
+        ]
+    )
     A01 = sparse([j == i + 1 ? i * σ_off : 0 for i in 1:Nmax, j in 1:Nmax])
 
     A10 = sparse([j == i - 1 ? σ_on : 0 for i in 1:Nmax, j in 1:Nmax])
-    A11 = sparse([j == i ? -(ρ_on + (i - 1) * (d + σ_off)) :
-                  j == i - 1 ? ρ_on : j == i + 1 ? i * d : 0 for i in 1:Nmax, j in 1:Nmax])
+    A11 = sparse(
+        [
+            j == i ? -(ρ_on + (i - 1) * (d + σ_off)) :
+                j == i - 1 ? ρ_on : j == i + 1 ? i * d : 0 for i in 1:Nmax, j in 1:Nmax
+        ]
+    )
 
     A = SparseMatrixCSC{Float64, Int64}([A00 A01; A10 A11])
 
     # Convert to column-major ordering used by Julia
     J = vec(reshape(1:(2 * Nmax), 2, Nmax)')
     P = sparse(1:(2 * Nmax), J, 1)
-    P' * A * P
+    return P' * A * P
 end
 
 A = create_A(ps, Nmax)
@@ -57,16 +67,16 @@ u0 = zeros(2, Nmax)
 u0[1] = 1.0
 
 prob = ODEProblem(sys, u0, maximum(tt), pmap)
-sol = solve(prob, Vern7(), abstol = 1e-6, saveat = tt)
+sol = solve(prob, Vern7(), abstol = 1.0e-6, saveat = tt)
 
 f = (du, u, p, t) -> mul!(vec(du), A, vec(u))
 
 probA = ODEProblem(f, u0, 20.0)
-solA = solve(probA, Vern7(), abstol = 1e-6, saveat = tt)
+solA = solve(probA, Vern7(), abstol = 1.0e-6, saveat = tt)
 
-@test sol.u[1] ≈ solA.u[1] atol=1e-4
-@test sol.u[2] ≈ solA.u[2] atol=1e-4
-@test sol.u[3] ≈ solA.u[3] atol=1e-4
+@test sol.u[1] ≈ solA.u[1] atol = 1.0e-4
+@test sol.u[2] ≈ solA.u[2] atol = 1.0e-4
+@test sol.u[3] ≈ solA.u[3] atol = 1.0e-4
 
 ## Steady-State Tests
 
@@ -77,7 +87,7 @@ function create_A_ss(ps, Nmax)
         A[i, i] -= sum(A[:, i])
     end
 
-    A
+    return A
 end
 
 A_ss = create_A_ss(ps, Nmax)
@@ -95,7 +105,7 @@ probA_ss = SteadyStateProblem(f, u0)
 solA_ss = solve(probA_ss, SSRootfind())
 solA_ss.u ./= sum(solA_ss.u)
 
-@test sol_ss.u ≈ solA_ss.u atol=1e-4
+@test sol_ss.u ≈ solA_ss.u atol = 1.0e-4
 
 ### Permutations
 
@@ -111,11 +121,11 @@ P = sparse(1:(2 * Nmax), idx_perm, 1)'
 @test A_perm ≈ P * A * P'
 
 prob_perm = ODEProblem(sys_perm, u0_perm, maximum(tt), pmap)
-sol_perm = solve(prob_perm, Vern7(), abstol = 1e-6, saveat = tt)
+sol_perm = solve(prob_perm, Vern7(), abstol = 1.0e-6, saveat = tt)
 
-@test sol_perm.u[1] ≈ sol.u[1]' atol=1e-4
-@test sol_perm.u[2] ≈ sol.u[2]' atol=1e-4
-@test sol_perm.u[3] ≈ sol.u[3]' atol=1e-4
+@test sol_perm.u[1] ≈ sol.u[1]' atol = 1.0e-4
+@test sol_perm.u[2] ≈ sol.u[2]' atol = 1.0e-4
+@test sol_perm.u[3] ≈ sol.u[3]' atol = 1.0e-4
 
 A_fsp_ss_perm = SparseMatrixCSC(sys_perm, (Nmax, 2), pmap, SteadyState())
 
@@ -125,4 +135,4 @@ prob_ss_perm = SteadyStateProblem(sys_perm, u0_perm, pmap)
 sol_ss_perm = solve(prob_ss_perm, SSRootfind())
 sol_ss_perm.u ./= sum(sol_ss_perm.u)
 
-@test sol_ss_perm.u ≈ sol_ss.u' atol=1e-4
+@test sol_ss_perm.u ≈ sol_ss.u' atol = 1.0e-4

--- a/test/telegraph.jl
+++ b/test/telegraph.jl
@@ -21,25 +21,27 @@ end
 sys = FSPSystem(rs)
 
 prs = [exp(2 * randn()), exp(2 * randn())]
-pmap = [:σ_on => rand(Gamma()),
+pmap = [
+    :σ_on => rand(Gamma()),
     :σ_off => rand(Gamma()),
     :ρ_m => prs[1],
     :δ_m => prs[1] / exp(2 * randn()),
     :ρ_p => prs[2],
-    :δ_p => prs[2] / exp(2 * randn())]
+    :δ_p => prs[2] / exp(2 * randn()),
+]
 
 ps = last.(pmap)
 
 Mmax = 20
 Pmax = 80
 
-u0 = zeros(2, Mmax+1, Pmax+1)
+u0 = zeros(2, Mmax + 1, Pmax + 1)
 u0[1] = 1.0
 
 tt = [1.0, 10.0, 50.0]
 
 prob = ODEProblem(sys, u0, 50.0, pmap)
-sol = solve(prob, Vern7(), abstol = 1e-6, saveat = tt)
+sol = solve(prob, Vern7(), abstol = 1.0e-6, saveat = tt)
 
 fspmean(xx) = dot(xx, 0:(length(xx) - 1))
 
@@ -48,30 +50,34 @@ mG_asym = ps[1] / (ps[1] + ps[2])
 for (i, t) in enumerate(tt)
     mG = mG_asym * (1 - exp(-(ps[1] + ps[2]) * t))
     mM = ps[3] * mG_asym *
-         (1 / ps[4] * (1 - exp(-ps[4] * t)) -
-          1 / (ps[4] - ps[1] - ps[2]) * (exp(-(ps[1] + ps[2]) * t) - exp(-ps[4]*t)))
+        (
+        1 / ps[4] * (1 - exp(-ps[4] * t)) -
+            1 / (ps[4] - ps[1] - ps[2]) * (exp(-(ps[1] + ps[2]) * t) - exp(-ps[4] * t))
+    )
     mP = ps[5] * ps[3] * mG_asym *
-         (1 / (ps[4] * ps[6]) * (1 - exp(-ps[6] * t)) -
-          1 / (ps[4] * (ps[6] - ps[4])) * (exp(-ps[4] * t) - exp(-ps[6] * t)) -
-          1 / ((ps[6] - ps[1] - ps[2]) * (ps[4] - ps[1] - ps[2])) *
-          (exp(-(ps[1] + ps[2]) * t) - exp(-ps[6]*t)) +
-          1 / ((ps[6] - ps[4]) * (ps[4] - ps[1] - ps[2])) *
-          (exp(-ps[4] * t) - exp(-ps[6]*t)))
+        (
+        1 / (ps[4] * ps[6]) * (1 - exp(-ps[6] * t)) -
+            1 / (ps[4] * (ps[6] - ps[4])) * (exp(-ps[4] * t) - exp(-ps[6] * t)) -
+            1 / ((ps[6] - ps[1] - ps[2]) * (ps[4] - ps[1] - ps[2])) *
+            (exp(-(ps[1] + ps[2]) * t) - exp(-ps[6] * t)) +
+            1 / ((ps[6] - ps[4]) * (ps[4] - ps[1] - ps[2])) *
+            (exp(-ps[4] * t) - exp(-ps[6] * t))
+    )
 
-    @test marg(sol.u[i], dims = (2, 3)) ≈ pdf.(Bernoulli(mG), 0:1) atol=1e-4
-    @test fspmean(marg(sol.u[i], dims = (1, 3))) ≈ mM atol=1e-2
-    @test fspmean(marg(sol.u[i], dims = (1, 2))) ≈ mP atol=1e-2
+    @test marg(sol.u[i], dims = (2, 3)) ≈ pdf.(Bernoulli(mG), 0:1) atol = 1.0e-4
+    @test fspmean(marg(sol.u[i], dims = (1, 3))) ≈ mM atol = 1.0e-2
+    @test fspmean(marg(sol.u[i], dims = (1, 2))) ≈ mP atol = 1.0e-2
 end
 
 A = SparseMatrixCSC(sys, size(u0), pmap, 0)
 f = (du, u, p, t) -> mul!(vec(du), A, vec(u))
 
 probA = ODEProblem(f, u0, 50.0)
-solA = solve(probA, Vern7(), abstol = 1e-6, saveat = tt)
+solA = solve(probA, Vern7(), abstol = 1.0e-6, saveat = tt)
 
-@test sol.u[1] ≈ solA.u[1] atol=1e-4
-@test sol.u[2] ≈ solA.u[2] atol=1e-4
-@test sol.u[3] ≈ solA.u[3] atol=1e-4
+@test sol.u[1] ≈ solA.u[1] atol = 1.0e-4
+@test sol.u[2] ≈ solA.u[2] atol = 1.0e-4
+@test sol.u[3] ≈ solA.u[3] atol = 1.0e-4
 
 ## Steady-State Tests
 
@@ -98,7 +104,7 @@ sys_perm = FSPSystem(rs, [:P, :M, :G])
 pdims(x) = permutedims(x, (3, 2, 1))
 u0_perm = pdims(u0)
 
-A_perm = SparseMatrixCSC(sys_perm, (Pmax+1, Mmax+1, 2), pmap, 0)
+A_perm = SparseMatrixCSC(sys_perm, (Pmax + 1, Mmax + 1, 2), pmap, 0)
 
 idx_perm = vec(pdims(reshape(1:prod(size(u0)), size(u0))))
 P = sparse(1:prod(size(u0)), idx_perm, 1)
@@ -106,11 +112,11 @@ P = sparse(1:prod(size(u0)), idx_perm, 1)
 @test A_perm ≈ P * A * P'
 
 prob_perm = ODEProblem(sys_perm, u0_perm, 50.0, pmap)
-sol_perm = solve(prob_perm, Vern7(), abstol = 1e-6, saveat = tt)
+sol_perm = solve(prob_perm, Vern7(), abstol = 1.0e-6, saveat = tt)
 
-@test sol_perm.u[1] ≈ pdims(sol.u[1]) atol=1e-4
-@test sol_perm.u[2] ≈ pdims(sol.u[2]) atol=1e-4
-@test sol_perm.u[3] ≈ pdims(sol.u[3]) atol=1e-4
+@test sol_perm.u[1] ≈ pdims(sol.u[1]) atol = 1.0e-4
+@test sol_perm.u[2] ≈ pdims(sol.u[2]) atol = 1.0e-4
+@test sol_perm.u[3] ≈ pdims(sol.u[3]) atol = 1.0e-4
 
 ## Steady-State Tests
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)