### PR TITLE
Documentation improvements: grammar, typos, and consistency

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -16,7 +16,7 @@ end
 sys = FSPSystem(rn)
 
 # Parameters for our system
-ps = [10.0, 1.0]
+ps = [:σ => 10.0, :d => 1.0]
 
 # Initial distribution (over 1 species)
 # Here we start with 0 copies of A
@@ -33,7 +33,7 @@ sol = solve(prob, Vern7())
 
 Here we showcase the telegraph model, a simplistic description of mRNA transcription in biological cells. We have one gene that transitions stochastically between an *on* and an *off* state and produces mRNA molecules while it is in the *on* state.
 
-The most straightforward description of this system includes three species: two gene states, `G_on` and `G_off`, and mRNA `M`. The state space for this system is 3-dimensional. We know, however, that `G_on` and `G_off` never occur at the same time, indeed the conservation law `[G_on] + [G_off] = 1` allows us to express the state of the system in terms of `G_on` and `M` only. The state space of this reduced system is 2-dimensional.If we use an mRNA cutoff of 100, the state space for the original model has size ``2 \times 2 \times 100 = 400``, while the reduced state space has size ``2 \times 100 = 200``, a two-fold saving. Since the FSP get computationally more expensive for each species in a system, eliminating redundant species as above is recommended for improved performance.
+The most straightforward description of this system includes three species: two gene states, `G_on` and `G_off`, and mRNA `M`. The state space for this system is 3-dimensional. We know, however, that `G_on` and `G_off` never occur at the same time, indeed the conservation law `[G_on] + [G_off] = 1` allows us to express the state of the system in terms of `G_on` and `M` only. The state space of this reduced system is 2-dimensional. If we use an mRNA cutoff of 100, the state space for the original model has size ``2 \times 2 \times 100 = 400``, while the reduced state space has size ``2 \times 100 = 200``, a two-fold saving. Since the FSP gets computationally more expensive for each species in a system, eliminating redundant species as above is recommended for improved performance.
 
 !!! note
     
@@ -53,7 +53,7 @@ end
 sys = FSPSystem(rn)
 
 # Parameters for our system
-ps = [0.25, 0.15, 15.0, 1.0]
+ps = [:σ_on => 0.25, :σ_off => 0.15, :ρ => 15.0, :d => 1.0]
 
 # Initial distribution (over two species)
 # Here we start with 0 copies of G_on and M

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,4 +27,4 @@ This function is generated dynamically as an `ODEFunction` for use with Differen
 
 ## Acknowledgments
 
-Special thanks to [Xiamong Fu](https://github.com/palmtree2013), [Brian Munsky](https://www.engr.colostate.edu/%7Emunsky/) and [Huy Vo](https://github.com/voduchuy) for their examples and suggestions and for contributing most of the content in the [Tips & Tricks](@ref tips) page!
+Special thanks to [Xiaoming Fu](https://github.com/palmtree2013), [Brian Munsky](https://www.engr.colostate.edu/%7Emunsky/) and [Huy Vo](https://github.com/voduchuy) for their examples and suggestions and for contributing most of the content in the [Tips & Tricks](@ref tips) page!

--- a/docs/src/tips.md
+++ b/docs/src/tips.md
@@ -1,6 +1,6 @@
 # [Tips and Tricks](@id tips)
 
-The FSP approximates an infinite-dimensional system of equations by truncating it to a finite number of variables. The accuracy of the FSP therefore depends on how many variables are retained, ie.~what portion of the state space is modelled. While simple reaction networks with 1 or 2 species are not too difficult to handle using the FSP, a naive approach will require unfeasibly large truncations for systems of even moderate complexity.
+The FSP approximates an infinite-dimensional system of equations by truncating it to a finite number of variables. The accuracy of the FSP therefore depends on how many variables are retained, i.e., what portion of the state space is modelled. While simple reaction networks with 1 or 2 species are not too difficult to handle using the FSP, a naive approach will require unfeasibly large truncations for systems of even moderate complexity.
 
 ## Solving Linear Equations
 
@@ -33,4 +33,4 @@ expmv!(vec(ut), t, A, vec(u0), tol=1e-6)  # really fast
 
 ## Further Comments
 
-Choosing the right solver for large systems of ODEs can result in time savings on the order of 10-100x, and it is recommended that you experiment with a few solvers to see which works best in your case. This section is still work in progress and there has been a lot of research on accelerating the FSP and extending it to larger reaction networks which will hopefully be reviewed here soon. Feel free to share any comments or suggestions in this direction at the [Github repository](https://github.com/kaandocal/FiniteStateProjection.jl)!
+Choosing the right solver for large systems of ODEs can result in time savings on the order of 10-100x, and it is recommended that you experiment with a few solvers to see which works best in your case. This section is still work in progress and there has been a lot of research on accelerating the FSP and extending it to larger reaction networks which will hopefully be reviewed here soon. Feel free to share any comments or suggestions in this direction at the [Github repository](https://github.com/SciML/FiniteStateProjection.jl)!

--- a/docs/src/troubleshoot.md
+++ b/docs/src/troubleshoot.md
@@ -4,7 +4,7 @@ Solving the Chemical Master Equation numerically is a difficult task and errors 
 
 ## Ensure your state space has the right dimension
 
-If your are solving an SIR model with three species, ``S``, ``I`` and ``R``, your state space will be 3-dimensional. FiniteStateProjection.jl computes probabilities for all states simultaneously and stores the results in a 3-dimensional array. In particular, `u0` must have type `Float64` or similar as it represents numbers between 0 and 1.
+If you are solving an SIR model with three species, ``S``, ``I`` and ``R``, your state space will be 3-dimensional. FiniteStateProjection.jl computes probabilities for all states simultaneously and stores the results in a 3-dimensional array. In particular, `u0` must have type `Float64` or similar as it represents numbers between 0 and 1.
 
 ```julia
 # correct
@@ -47,7 +47,7 @@ end
 sys_fsp = FSPSystem(rn)
 ```
 
-Here the propensity function for the first reaction will negative if ``I > N``, so the following may result in numerical instabilities:
+Here the propensity function for the first reaction will be negative if ``I > N``, so the following may result in numerical instabilities:
 
 ```julia
 u0 = zeros(30)


### PR DESCRIPTION
## Summary

This PR improves the documentation quality with several focused fixes:

- **Grammar fixes**: 
  - "your are" → "you are" (troubleshoot.md:7)
  - "will negative" → "will be negative" (troubleshoot.md:50)
  - "ie.~what" → "i.e., what" (tips.md:3)
  - "get" → "gets" (examples.md:36)
  - Added missing space after period (examples.md:36)

- **Typo fixes**:
  - "Xiamong Fu" → "Xiaoming Fu" (index.md:30)

- **Consistency improvements**:
  - Updated repository link from `kaandocal/FiniteStateProjection.jl` to `SciML/FiniteStateProjection.jl` (tips.md:36)
  - Aligned parameter syntax in examples.md to use symbolic form (e.g., `[:σ => 10.0, :d => 1.0]`) for consistency with README.md

All changes are non-functional and preserve the author's voice and style. The improvements make the documentation clearer and more consistent for users.

cc: @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)