### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,32 @@
+name: "Downgrade"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  downgrade:
+    name: "Downgrade"
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - Core
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: ${{ matrix.group }}
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,9 @@
+name: "Spell Check"
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What changed

This converts CI to use the centralized SciML reusable workflows for everything (pinned `@v1`, `secrets: "inherit"` on every caller).

### Converted (inline -> central)
- **Runic** (`FormatCheck.yml`): inline `fredrikekre/runic-action` -> `runic.yml@v1` caller. Existing inline run was already clean, so no formatting changes were needed.

### Added (new central callers)
- **SpellCheck** (`SpellCheck.yml`): `spellcheck.yml@v1`. `typos .` runs clean (0 findings), no `_typos.toml` needed.
- **Downgrade** (`Downgrade.yml`): `downgrade.yml@v1` with `julia-version: "lts"`, `skip: "Pkg,TOML"`, preserving the `group: [Core]` matrix used by Tests.

### Already central (left as-is, `secrets: "inherit"` confirmed)
- **Tests** (`Tests.yml`): `tests.yml@v1`, matrix `group: [Core]`, `julia-version: "1"`.
- **Documentation** (`Documentation.yml`): `documentation.yml@v1`.

### Unchanged
- `TagBot.yml`, `dependabot.yml` (already has weekly `github-actions` block at `/` and daily `julia` block over `/`, `/docs`, `/test`; no `crate-ci/typos` ignore present). No `CompatHelper.yml` existed.

### Notes
- Typos fixed: 0. Runic formatting applied: no (already clean).
- No Downstream or Benchmark workflows existed, so none were added.

⚠️ Check names change (e.g. the Runic job is now `Runic` / `Runic Format Check`, plus new `Downgrade` and `Spell Check with Typos` jobs). Branch-protection required-status-check names will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)