### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,15 +18,6 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: ${{ matrix.group }}
-      julia-version: '1'
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"
-    
+

--- a/Project.toml
+++ b/Project.toml
@@ -14,12 +14,16 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Catalyst = "15"
 DiffEqBase = "6, 7"
+Distributions = "0.25"
+LinearAlgebra = "1"
 MacroTools = "^0.5.5"
 OrdinaryDiffEq = "6, 7"
 Reexport = "1"
 RuntimeGeneratedFunctions = "0.5"
+SafeTestsets = "0.1"
 SteadyStateDiffEq = "1, 2"
 Sundials = "4, 5, 6"
+Test = "1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -30,10 +30,11 @@ julia = "1.10"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "LinearAlgebra", "OrdinaryDiffEq", "SafeTestsets", "SteadyStateDiffEq", "Sundials", "Test"]
+test = ["Distributions", "LinearAlgebra", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "SteadyStateDiffEq", "Sundials", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,8 @@ MacroTools = "^0.5.5"
 OrdinaryDiffEq = "6, 7"
 Reexport = "1"
 RuntimeGeneratedFunctions = "0.5"
-SafeTestsets = "0.1"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 SteadyStateDiffEq = "1, 2"
 Sundials = "4, 5, 6"
 Test = "1"
@@ -30,11 +31,11 @@ julia = "1.10"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "LinearAlgebra", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "SteadyStateDiffEq", "Sundials", "Test"]
+test = ["Distributions", "LinearAlgebra", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "SteadyStateDiffEq", "Sundials", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FiniteStateProjection = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,7 @@ FiniteStateProjection = { path = "../.." }
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FiniteStateProjection = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+FiniteStateProjection = { path = "../.." }
+
+[compat]
+Aqua = "0.8"
+JET = "0.9,0.10,0.11"
+Test = "1"
+julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FiniteStateProjection = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using FiniteStateProjection
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(FiniteStateProjection)
+end
+
+@testset "JET" begin
+    JET.test_package(FiniteStateProjection; target_defined_modules = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,24 @@
-using SafeTestsets
+using SafeTestsets, Pkg
+
+const GROUP = get(ENV, "GROUP", "All")
 
 @time begin
-    @safetestset "Telegraph" begin
-        include("telegraph.jl")
+    if GROUP == "All" || GROUP == "Core"
+        @safetestset "Telegraph" begin
+            include("telegraph.jl")
+        end
+        @safetestset "FeedbackLoop" begin
+            include("feedbackloop.jl")
+        end
+        @safetestset "BirthDeath2D" begin
+            include("birthdeath2D.jl")
+        end
     end
-    @safetestset "FeedbackLoop" begin
-        include("feedbackloop.jl")
-    end
-    @safetestset "BirthDeath2D" begin
-        include("birthdeath2D.jl")
+
+    if GROUP == "QA"
+        Pkg.activate(joinpath(@__DIR__, "qa"))
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+        Pkg.instantiate()
+        include("qa/qa.jl")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,3 @@
-using SafeTestsets, Pkg
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-@time begin
-    if GROUP == "All" || GROUP == "Core"
-        @safetestset "Telegraph" begin
-            include("telegraph.jl")
-        end
-        @safetestset "FeedbackLoop" begin
-            include("feedbackloop.jl")
-        end
-        @safetestset "BirthDeath2D" begin
-            include("birthdeath2D.jl")
-        end
-    end
-
-    if GROUP == "QA"
-        Pkg.activate(joinpath(@__DIR__, "qa"))
-        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-        Pkg.instantiate()
-        include("qa/qa.jl")
-    end
-end
+run_tests()

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root test workflow to the canonical SciML thin-caller pattern: the test matrix is declared once in a root `test/test_groups.toml`, and the workflow becomes a thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`.

### Changes
- **`.github/workflows/Tests.yml`** (root test workflow, kept filename + `name: "Run Tests"`): the hand-maintained `group` matrix job replaced by the thin `grouped-tests.yml@v1` caller. `on:` and `concurrency:` preserved verbatim. No `with:` overrides needed — runtests reads the default `GROUP` env, defaults (`check-bounds: yes`, `coverage: true`, `coverage-directories: src,ext`) all apply. Linux-only (no `os` field).
- **`test/test_groups.toml`** (new, repo root): `Core` on `[lts, 1, pre]`, `QA` on `[lts, 1]`.
- **`test/runtests.jl`**: added `GROUP` dispatch. Existing suites (Telegraph, FeedbackLoop, BirthDeath2D) run under `Core` (and `All`). The `QA` group activates the isolated `test/qa` env and runs Aqua/JET.
- **`test/qa/`** (new): isolated environment (`Aqua` + `JET` + `Test` + `FiniteStateProjection` via `[sources]` path) and `qa.jl` running `Aqua.test_all(FiniteStateProjection)` and `JET.test_package(FiniteStateProjection; target_defined_modules=true)`.
- **`Project.toml`**: added `[compat]` entries for the test-only `[extras]` that were missing them (`Distributions`, `LinearAlgebra`, `SafeTestsets`, `Test`). `julia` compat already at the `1.10` LTS floor (unchanged).

### Matrix match
Verified statically via `scripts/compute_affected_sublibraries.jl --root-matrix` (from `SciML/.github@v1`). Emitted matrix:

```
Core @ lts    (ubuntu-latest)
Core @ 1      (ubuntu-latest)   <- preserves the OLD matrix's only cell
Core @ pre    (ubuntu-latest)
QA   @ lts    (ubuntu-latest)
QA   @ 1      (ubuntu-latest)
```

The previous workflow ran a single cell `(Core, julia '1')`. That cell is preserved; the remaining cells (`Core` on `lts`/`pre`, plus the new `QA` group) are the canonical Category C expansion.

QA group is newly wired; Aqua/JET run in CI — any failures will be triaged in a follow-up.

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)