### PR TITLE
Fix Downgrade (Core) and Aqua/JET QA failures

### DIFF
--- a/src/indexhandlers.jl
+++ b/src/indexhandlers.jl
@@ -86,16 +86,28 @@ function pairedindices(
     return pairedindices(ih, axes(arr), shift)
 end
 
+# `dims` is written as `Tuple{T, Vararg{T}}` rather than `NTuple{N, T}` so that the
+# element type `T` is always bound: `NTuple{0, T} === Tuple{}` leaves `T` free, which
+# trips Aqua's unbound-type-parameter check. The zero-dimensional case is handled by the
+# explicit method below.
 function pairedindices(
-        ih::DefaultIndexHandler{N}, dims::NTuple{N, T},
+        ih::DefaultIndexHandler{N}, dims::Tuple{T, Vararg{T}},
         shift::CartesianIndex{N}
     ) where {N, T <: Number}
     return pairedindices(ih, Base.OneTo.(dims), shift)
 end
 
+# Handles the degenerate zero-dimensional case (no species), where neither `T`-constrained
+# method below matches because `Tuple{}` has no element type.
+function pairedindices(
+        ::DefaultIndexHandler{0}, ::Tuple{}, ::CartesianIndex{0}
+    )
+    return zip(CartesianIndices(()), CartesianIndices(()))
+end
+
 # Important: the species in `shift` are ordered according to `Catalyst.species`!
 function pairedindices(
-        ih::DefaultIndexHandler{N}, dims::NTuple{N, T},
+        ih::DefaultIndexHandler{N}, dims::Tuple{T, Vararg{T}},
         shift::CartesianIndex{N}
     ) where {N, T <: AbstractVector}
     ranges = tuple(
@@ -114,9 +126,9 @@ function pairedindices(
 end
 
 function pairedindices(
-        ::DefaultIndexHandler, dims::NTuple{N, T},
-        shift::CartesianIndex{M}
-    ) where {N, M, T <: AbstractVector}
+        ::DefaultIndexHandler, dims::Tuple,
+        shift::CartesianIndex
+    )
     return @error "Dimension of state space ($(length(dims))) does not match number of species ($(length(shift)))"
 end
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -22,9 +22,6 @@ run_qa(
         :unbound_args,       # pairedindices unbound type params (indexhandlers.jl 97/116)
         :undefined_exports,  # @reexport using Catalyst re-exports names absent from loaded deps
     ),
-    # JET reports 3 issues (NaiveIndexHandler @deprecate kwcall; NullParameters used
-    # but not imported in build_rhs.jl/build_rhs_ss.jl). Tracked in #60.
-    jet_broken = true,
     ei_kwargs = (;
         # Names re-exported by a non-owner dependency (resolve to the owner as base
         # libraries adopt public/owner declarations).


### PR DESCRIPTION
## Summary

Fixes the **Downgrade (Core)** check and the Aqua **method-ambiguity / unbound-type-parameter / deps-compat** and **JET** sub-checks of the QA jobs on `main`. All fixes were reproduced and verified locally on the failing Julia versions before committing.

### 1. Downgrade (Core) — `SteadyStateDiffEq` compat floor

The downgrade job failed precompiling `SteadyStateDiffEq` with `UndefVarError: AbstractNonlinearTerminationMode not defined` (its `solve.jl:70` references `SciMLBase.AbstractNonlinearTerminationMode`). The old floor `SteadyStateDiffEq = "1, 2"` let the downgrade resolver pick a `SteadyStateDiffEq` paired with a `SciMLBase` too old to define that symbol. Raised to `SteadyStateDiffEq = "2.5"`, which forces a `SciMLBase` floor (resolved 2.99.0) that defines it. Also added the missing `SparseArrays = "1"` compat (fixes the Aqua deps-compat failure) and raised the `DiffEqBase` floor to `6.140` for downgrade resolvability.

### 2. QA / Aqua — method ambiguity + unbound type parameters

`pairedindices(::DefaultIndexHandler{N}, ::NTuple{N,T}, ::CartesianIndex{N})` had a `T<:Number`/`T<:AbstractVector` pair that was ambiguous at `N == 0` (`NTuple{0,T} === Tuple{}` leaves `T` free) and an `AbstractVector` fallback with unbound `M`/`T`. Rewrote the two methods using `Tuple{T, Vararg{T}}` (so `T` is always bound) plus an explicit zero-dimensional method, and dropped the unused type params on the dimension-mismatch fallback.

### 3. QA / JET — `NullParameters`

`NullParameters` is not exported from `DiffEqBase`, so the bare default-arg references in `build_rhs.jl` / `build_rhs_ss.jl` were undefined bindings. Qualified as `DiffEqBase.NullParameters()`. This also clears the JET `iterate(::Nothing)` cascade that stemmed from the ambiguous/unbound `pairedindices` methods.

## Verification (run locally)

- **Downgrade Core, Julia 1.10 (lts)** with the `=floor`-rewritten compat: telegraph 17/17, feedbackloop 12/12, birthdeath2D 18/18, tests passed. (CI: Downgrade (Core) is now green.)
- **Core, Julia 1.12 (`1`)**: telegraph 17/17, feedbackloop 12/12, birthdeath2D 18/18, tests passed.
- **Aqua** `test_ambiguities` / `test_unbound_args` (1/1) / `test_deps_compat` (4/4), and **JET** `test_package(...; target_defined_modules=true)` (1/1): all pass on Julia 1.12 against the package project.
- Runic-formatted all changed `.jl` files (`runic --check` clean).

## Remaining QA failure (upstream Catalyst — not fixable here)

The Aqua `test_undefined_exports` sub-check is still red. The undefined exports — `CartesianGridReJ`, `infimum`, `iscall`, `params`, `supremum` — are **all inherited via `@reexport using Catalyst`**; FiniteStateProjection's own exports (`FSPSystem`, `DefaultIndexHandler`, `SteadyState`) are all defined.

This is conclusively an upstream Catalyst bug, not an FSP defect. **Catalyst itself fails the same Aqua check**: running the equivalent of `Aqua.test_undefined_exports` against `Catalyst` directly reports `[:CartesianGridReJ, :infimum, :params, :supremum]` as undefined exports of Catalyst. FSP inherits those four plus `iscall` (the extra one is a `@reexport` double-hop: `iscall` is `using`-imported into Catalyst from TermInterface, so it is `isdefined(Catalyst, :iscall)` but is not re-bound in FSP).

- `CartesianGridReJ` (uppercase `J`) is a literal **export typo in Catalyst** — `src/Catalyst.jl` exports `CartesianGridReJ` while the type defined in JumpProcesses (and used everywhere else in Catalyst) is `CartesianGridRej` (lowercase `j`). The uppercase-`J` symbol is defined in **no** module in the dependency tree, so it cannot be made `isdefined` in FSP without inventing a fake binding. The typo is present on Catalyst 15.0.11 (the latest 15.x) and on Catalyst master.
- `infimum`, `supremum`, `params` are `using`-imported-then-`export`ed by Catalyst from ModelingToolkit / Symbolics / DomainSets and do not propagate transitive bindings through `@reexport using Catalyst`.

Bumping to Catalyst 16.2 does **not** fix this (it yields a different set of undefined re-exports and additionally breaks FSP's Core tests — see the dependabot Catalyst-16.2 PR, whose Core jobs are red). Making this check green requires an upstream Catalyst fix (at minimum, fixing the `CartesianGridReJ` -> `CartesianGridRej` export typo). It cannot be fixed inside FiniteStateProjection without disabling/excluding the check or fabricating a binding.

## Note on the `Core (julia pre)` CI job

On a later CI run this PR shows 3 failing asserts in `birthdeath2D.jl` (steady-state marginal/permutation tests, `atol=1e-4`) on the `julia pre` channel (`1.13.0-rc1`). This is **not** a regression from this PR: the same job was green on `main`, the resolved dependency set is byte-identical between the two runs (same `SteadyStateDiffEq 2.11.0`, `NonlinearSolve 4.16.0`, `Catalyst 15.0.11`, `SciMLBase 2.153.1`), and locally on `1.13.0-rc1` with that exact resolved environment `birthdeath2D` passes 18/18 (reproduced twice). The failures are borderline-tolerance numerical drift in the `SSRootfind` steady-state solve on the Julia release candidate, not a deterministic FSP change.

This PR makes Downgrade fully green and reduces QA from 5 failing Aqua/JET sub-checks to the single upstream-blocked `test_undefined_exports` check.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
