### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/docs/src/mainapi.md
+++ b/docs/src/mainapi.md
@@ -23,9 +23,10 @@ DiffEqBase.ODEProblem(::FSPSystem, u0, tmax, p)
 
 ## Steady-State Problems
 
-Computing steady-state distributions can be done using the SteadyStateDiffEq.jl package. At the moment FiniteStateProjection.jl adjusts the rate matrix so that reactions leaving the truncated state space have propensity 0.
+Computing steady-state distributions can be done using the SteadyStateDiffEq.jl package. At the moment FiniteStateProjection.jl adjusts the rate matrix so that reactions leaving the truncated state space have propensity 0. Pass a [`SteadyState`](@ref) instance to the conversion methods to request this steady-state formulation.
 
 ```@docs
+SteadyState
 Base.convert(::Type{ODEFunction}, ::FSPSystem, ::SteadyState)
 DiffEqBase.SteadyStateProblem(::FSPSystem, u0, p)
 ```

--- a/src/build_rhs_ss.jl
+++ b/src/build_rhs_ss.jl
@@ -1,3 +1,18 @@
+"""
+    struct SteadyState end
+
+Marker type used to select the steady-state formulation of the Chemical
+Master Equation. Passing a `SteadyState()` instance to the conversion and
+matrix-building methods requests the right-hand side in which transitions
+out of the truncated state space are dropped (their propensity is set to
+zero), as required for solving for the stationary distribution rather than
+the time-dependent one.
+
+It is used as a dispatch tag by
+[`Base.convert(::Type{ODEFunction}, ::FSPSystem, ::SteadyState)`](@ref),
+[`SparseArrays.SparseMatrixCSC(::FSPSystem, ::NTuple, ps, ::SteadyState)`](@ref)
+and [`DiffEqBase.SteadyStateProblem(::FSPSystem, u0, p)`](@ref).
+"""
 struct SteadyState end
 
 """


### PR DESCRIPTION
## Summary

`SteadyState` is part of the exported public API (`export FSPSystem, DefaultIndexHandler, SteadyState`) but had **neither a docstring nor a rendered-docs entry**. It only appeared inside method signatures (`::SteadyState`) on the Main API and Matrix Conversions pages, never documented in its own right.

This PR closes that gap:

- **Docstring**: adds a docstring to `struct SteadyState end` (`src/build_rhs_ss.jl`) describing it as the marker/dispatch type that selects the steady-state formulation of the CME (transitions out of the truncated state space dropped to propensity 0), matching the docstring style of `FSPSystem` and `DefaultIndexHandler`. Cross-links the three methods that dispatch on it.
- **Docs entry**: adds a standalone `SteadyState` entry to the `@docs` block in `docs/src/mainapi.md` (Steady-State Problems section) so it is rendered.

The other two exported names (`FSPSystem`, `DefaultIndexHandler`) already have both a docstring and a docs entry — verified by loading the package and checking `Base.Docs.doc` for every FSP-owned public name.

## Validation

- Loaded the package (Julia 1.12.6): the only FSP-owned exported names are `FSPSystem`, `DefaultIndexHandler`, `SteadyState`; only `SteadyState` lacked a docstring on `main`.
- `@doc SteadyState` is now non-empty and attaches the new docstring.
- Built the docs with `docs/make.jl` (Documenter default `checkdocs`, **no `warnonly`**): completes cleanly, `CheckDocument`/`CrossReferences` pass with no missing-docstring errors, and the rendered `mainapi.html` contains the `SteadyState` docstring block with anchor `id="FiniteStateProjection.SteadyState"`.
- Runic clean on the changed source file.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)