### PR TITLE
Bump version to 0.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteStateProjection"
 uuid = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
 authors = ["kaandocal"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Automated patch version bump (0.3.4 -> 0.3.5) to release unreleased commits on `main` via JuliaRegistrator.