### PR TITLE
Release prep: bump version to 0.3.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteStateProjection"
 uuid = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
 authors = ["kaandocal"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
## Summary

Bumps the `version` field in Project.toml from `0.3.5` to `0.3.6`. There are no unreleased-commit version bumps pending prior to this — the last registered version (0.3.5, tree-sha `f0bb6e1324dd44040b601828d00b5e905ef91b27`) matches commit 5040f82 ("Bump version to 0.3.5 (#65)"). Since then, one PR has landed on `main`:

- #66 "Update SciMLTesting QA compat to 2.1", which bundles:
  - A **bug fix** to `pmap_to_p` in `src/fspsystem.jl`: parameter-map handling was rewritten to correctly resolve parameter values (previously relied on `ModelingToolkit.varmap_to_vars`, now does an explicit symbol-keyed lookup), and adds `SciMLBase.NullParameters` short-circuiting. Commit message: "Fix FiniteStateProjection ModelingToolkit integration".
  - `ODEFunction{true}` → `ODEFunction{true, SciMLBase.FullSpecialize}` in `build_rhs.jl`/`build_rhs_ss.jl` (specialization hint, non-breaking).
  - Formalizes `ModelingToolkit` as a direct dependency (`[deps]` + `compat = "9, 10, 11"`) — it was already being used unqualified via the `@reexport using Catalyst` chain; this just makes the existing usage explicit and adds a matching compat bound consistent with what `Catalyst = "15, 16.2"` already resolves.
  - Test-only changes: seeds the telegraph test RNG for determinism, adds `Random` as a test dependency, bumps the QA-only `SciMLTesting` compat floor to `2.1` and updates `test/qa/qa.jl` for the new `api_docs_kwargs` check.

## Bump-type rationale

**PATCH** (0.3.5 → 0.3.6). The only runtime-source change is a bug fix (correct parameter-map resolution) plus an internal specialization hint; no new exported API or backward-compatible feature was added. Per SemVer/pre-1.0 convention, breaking changes would warrant a MINOR bump, but nothing here appears breaking — `pmap_to_p` continues to accept the same call patterns, it just resolves them correctly. Everything else (QA/test infra, compat-floor bookkeeping) is non-functional for downstream users.

## Compat bounds

Left as-is. The diff's own `ModelingToolkit = "9, 10, 11"` addition and `SciMLTesting = "2.1"` floor bump already match the new usage (`ModelingToolkit.value`, `api_docs_kwargs`), so no further compat changes were needed.