### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -51,10 +51,12 @@ run_qa(
         ),
     ),
     api_docs_kwargs = (;
+        rendered = true,
         # `@reexport using Catalyst` intentionally exposes Catalyst's symbolic
         # stack. Require docstrings for FiniteStateProjection-owned public API
         # here, and leave dependency API docs to their owner packages.
         ignore = API_DOCS_IGNORE,
+        rendered_ignore = API_DOCS_IGNORE,
     ),
     # Heavy `@reexport using Catalyst` plus the symbolic stack make ~23 names
     # implicit; making them all explicit is a risky mass refactor. Tracked in #60.


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Enable SciMLTesting rendered public API docs coverage for FiniteStateProjection.jl.
- Pass the existing Catalyst re-export ignore list to both docstring and rendered-docs checks.
- No source behavior, docs pages, or package tests were changed.

## Audit

Package-owned exported/public API audited:

- `FSPSystem`
- `DefaultIndexHandler`
- `SteadyState`

All three already have source docstrings and rendered docs entries. Catalyst re-exports remain ignored because they are dependency-owned API.

## Validation

- `git diff --check` passed.
- No `[sources]` or `path = ...` entries found in docs/QA project files.
- QA command: `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`
  - Public API documentation passed: 2/2, including rendered docs.
  - Overall QA still failed on the existing JET report for deprecated `NaiveIndexHandler`; this PR does not mark that broken or change behavior.
- Docs command: `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` passed with only the local deploy warning and dependency `iscall` warning.
- Root-manifest package test command failed before tests because checked-in `Manifest.toml` was resolved with Julia 1.12.5 and Julia 1.10 could not locate `JuliaSyntaxHighlighting`.
- Fresh Julia 1.10 package test command: `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.test("FiniteStateProjection")'` passed:
  - `Core/birthdeath2D.jl`: 18/18
  - `Core/feedbackloop.jl`: 12/12
  - `Core/telegraph.jl`: 17/17
- Runic v1.7.0 `Runic.main(["--check", "."])` passed.
