### PR TITLE
Make birth-death steady-state test deterministic

### DIFF
--- a/test/birthdeath2D.jl
+++ b/test/birthdeath2D.jl
@@ -6,9 +6,12 @@ using FiniteStateProjection
 using Catalyst
 using SparseArrays
 using LinearAlgebra
+using Random
 using Sundials
 
 marg(vec; dims) = dropdims(sum(vec; dims); dims)
+
+Random.seed!(1234)
 
 rs = @reaction_network begin
     r1, 0 --> A


### PR DESCRIPTION
## Summary
- seed the randomized birth-death steady-state regression
- retain the existing solver and all analytical assertions/tolerances

## Validation
- `julia +1.12 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`\n\nIgnore until reviewed by @ChrisRackauckas.